### PR TITLE
chore: add publish github action workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Use node.js 14.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - name: NPM Install
+        run: npm ci
+      - name: Check Format
+        run: npm run format:check
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm run test
+      - uses: JasonEtco/build-and-tag-action@v2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag_name: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
This PR adds a `publish` workflow. It will also automatically pin the major semver version to the latest tagged release.