### PR TITLE
Upgrade everything to node 24

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - name: Use node.js 22.x
+      - name: Use node.js 24.x
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
       - name: NPM Install
         run: npm ci
       - name: Check Format

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Use node.js 24.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
       - name: NPM Install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Use node.js 24.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
       - name: NPM Install
@@ -26,7 +26,7 @@ jobs:
         run: npm run build
       - name: Test
         run: npm run test
-      - uses: JasonEtco/build-and-tag-action@v2
+      - uses: JasonEtco/build-and-tag-action@dd5e4991048c325f6d85b4155e586fc211c644da # v2.0.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
-      - name: Use node.js 22.x
+      - name: Use node.js 24.x
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
       - name: NPM Install
         run: npm ci
       - name: Check Format

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The GitHub Action could look like this:
 
 ```yaml
 - name: configure AWS creds
-  uses: aws-actions/configure-aws-credentials@v4
+  uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
   with:
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -113,9 +113,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: configure AWS creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.INT_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.INT_AWS_SECRET_ACCESS_KEY }}
@@ -133,9 +133,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: configure AWS creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.PRD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PRD_AWS_SECRET_ACCESS_KEY }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 **_Trigger AWS CodePipeline from GitHub Actions and have the possibility to
 wait for the execution result_**
 
+## Releasing
+
+1. Push changes to a branch (no need to merge to master first)
+2. Create a GitHub release targeting that branch with a semver tag (e.g. `v2.3.0`)
+3. The [publish workflow](.github/workflows/publish.yml) runs automatically: builds the ncc bundle and force-pushes it back to the tag
+
+The committed `dist/` is plain tsc - the publish workflow is what produces the bundled dist that consumers actually run.
+Do not manually commit ncc output.
+
 ## Intro
 
 If you want to control the deployment from GitHub Actions, but have specific
@@ -72,14 +81,14 @@ The GitHub Action could look like this:
 
 ```yaml
 - name: configure AWS creds
-  uses: aws-actions/configure-aws-credentials@v1-node16
+  uses: aws-actions/configure-aws-credentials@v4
   with:
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
     aws-region: eu-central-1
 - name: Start CodePipeline
-  uses: moia-oss/aws-codepipeline-trigger@v2
+  uses: moia-oss/aws-codepipeline-trigger@v2.2.0
   with:
     pipeline: my-pipeline
     wait: true # optional (default: false)
@@ -104,16 +113,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: configure AWS creds
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.INT_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.INT_AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.INT_AWS_SESSION_TOKEN }}
           aws-region: eu-central-1
       - name: Start CodePipeline
-        uses: moia-oss/aws-codepipeline-trigger@v2
+        uses: moia-oss/aws-codepipeline-trigger@v2.2.0
         with:
           pipeline: my-pipeline-int
           wait: true
@@ -124,16 +133,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: configure AWS creds
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.PRD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PRD_AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.PRD_AWS_SESSION_TOKEN }}
           aws-region: eu-central-1
       - name: Start CodePipeline
-        uses: moia-oss/aws-codepipeline-trigger@v2
+        uses: moia-oss/aws-codepipeline-trigger@v2.2.0
         with:
           pipeline: my-pipeline-prd
           wait: true

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'cloud'


### PR DESCRIPTION
previous attempt failed bc node22 is not supported for `using:` and didn't fail in CI here bc the /action.yaml is not executed

see https://github.com/moia-oss/aws-codepipeline-trigger/pull/237 and https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runsusing-for-javascript-actions

---

Or we just needed to cut a release 
tested in https://github.com/moia-dev/maas-blade-asw/actions/runs/25163249092/job/73762803183
